### PR TITLE
Fix missing decoded field in Log event

### DIFF
--- a/event-stream/common/src/main/java/net/consensys/besu/plugins/stream/core/EventStreamPlugin.java
+++ b/event-stream/common/src/main/java/net/consensys/besu/plugins/stream/core/EventStreamPlugin.java
@@ -183,6 +183,8 @@ public abstract class EventStreamPlugin<T extends EventStreamConfiguration> impl
                                 listener),
                         events::removeLogListener) // add log listener from config file
                     .subscribeAll());
+
+    configuration.loadEventSchemas();
   }
 
   @Override

--- a/event-stream/common/src/main/java/net/consensys/besu/plugins/stream/core/Serializer.java
+++ b/event-stream/common/src/main/java/net/consensys/besu/plugins/stream/core/Serializer.java
@@ -145,10 +145,8 @@ public interface Serializer {
             .put("removed", logWithMetadata.isRemoved())
             .put("logIndex", QuantityFormatter.format(logWithMetadata.getLogIndex()));
 
-    try {
+    if (logWithMetadata instanceof DecodedLogWithMetadata) {
       result.put("decoded", ((DecodedLogWithMetadata) logWithMetadata).getDecoded());
-    } catch (final ClassCastException e) {
-      LOG.warn(e);
     }
     return result;
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 version=1.0.0-SNAPSHOT
-besuVersion=1.5.0
+besuVersion=1.5.5
 distributionIdentifier=besu-plugins
 distributionBaseUrl=https://bintray.com/hyperledger-org/besu-repo/download_file?file_path=


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/besu-plugins/blob/master/CONTRIBUTING.md -->

## PR Description

The decoded field was missing in the Log event

#### Result
```
{
  "uuid": "1c7a045b-056c-4167-94ef-d412a0373b2e",
  "type": "LogEmitted",
  "timestamp": 1602164638604,
  "event": {
    "blockNumber": "0x14",
    "blockHash": "0xae96536508fc741c53c9c533e17a7640e1e3ad769840cc4d1e24cae452149d48",
    "transactionHash": "0xa5a69dbc49491e30ae7ee911c5199aa976303347f63f57b6de1af6e9083b691d",
    "transactionIndex": "0x0",
    "address": "0x42699a7612a82f1d9c36148af9c77354759b210b",
    "data": "0x000000000000000000000000000000000000000000000000000000000000000c",
    "topics": "[0x400b17a31df3410127b20d7bdfda2280986d454556feb4ee68a0ca6bc2d89309, 0x000000000000000000000000fe3b557e8fb62b89f4916b721be55ceb828dbd73]",
    "removed": false,
    "logIndex": "0x0",
    "decoded": "StoreEvent(0xfe3b557e8fb62b89f4916b721be55ceb828dbd73,12)"
  }
```

#### Test performed

Tested on a clique local network :
   - Published contract and emit event
   - Tried contract filtering
   - Check log event on Kafka

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.