### PR TITLE
Add feature to disable specific topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,6 @@
 # Changelog
+
+## 1.0.0
+
+### Additions and Improvements
+* Add new CLI option `--plugin-kafka-enabled-topic` to enable specific topics in the event stream feature. [\#19](https://github.com/ConsenSys/besu-plugins/pull/19)

--- a/event-stream/common/src/main/java/net/consensys/besu/plugins/stream/api/config/CommonConfiguration.java
+++ b/event-stream/common/src/main/java/net/consensys/besu/plugins/stream/api/config/CommonConfiguration.java
@@ -16,12 +16,14 @@ package net.consensys.besu.plugins.stream.api.config;
 
 import net.consensys.besu.plugins.stream.core.config.EventSchemas;
 import net.consensys.besu.plugins.stream.core.config.LogFilterTopicsWrapper;
+import net.consensys.besu.plugins.stream.model.DomainObjectType;
 import net.consensys.besu.plugins.types.Address;
 
 import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -36,8 +38,9 @@ public class CommonConfiguration implements EventStreamConfiguration {
   protected String topic = "pegasys-stream";
   protected String brokerUrl = "127.0.0.1:9092";
   protected boolean metadataDBEnabled = true;
-  protected LogFilterTopicsWrapper logFilterTopicsWrapper = LogFilterTopicsWrapper.empty();
   protected List<Address> logFilterAddresses = new ArrayList<>();
+  protected LogFilterTopicsWrapper logFilterTopicsWrapper = LogFilterTopicsWrapper.empty();
+  protected Optional<List<DomainObjectType>> enabledTopics = Optional.empty();
   protected File eventSchemasFile;
 
   private EventSchemas eventSchemas = EventSchemas.empty();
@@ -60,6 +63,11 @@ public class CommonConfiguration implements EventStreamConfiguration {
   @Override
   public boolean isMetadataDBEnabled() {
     return metadataDBEnabled;
+  }
+
+  @Override
+  public List<DomainObjectType> getEnabledTopics() {
+    return enabledTopics.orElse(Arrays.asList(DomainObjectType.values()));
   }
 
   @Override
@@ -112,6 +120,10 @@ public class CommonConfiguration implements EventStreamConfiguration {
 
   public void setMetadataDBEnabled(boolean metadataDBEnabled) {
     this.metadataDBEnabled = metadataDBEnabled;
+  }
+
+  public void setEnabledTopics(List<DomainObjectType> enabledTopics) {
+    this.enabledTopics = Optional.of(enabledTopics);
   }
 
   public void setLogFilterTopicsWrapper(LogFilterTopicsWrapper logFilterTopicsWrapper) {

--- a/event-stream/common/src/main/java/net/consensys/besu/plugins/stream/core/EventStreamPlugin.java
+++ b/event-stream/common/src/main/java/net/consensys/besu/plugins/stream/core/EventStreamPlugin.java
@@ -140,6 +140,7 @@ public abstract class EventStreamPlugin<T extends EventStreamConfiguration> impl
         .ifPresent(
             events -> {
               final List<DomainObjectType> enabledTopics = configuration.getEnabledTopics();
+              LOGGER.info("Enabled Kafka topics {}", enabledTopics);
               if (enabledTopics.contains(BLOCK)) {
                 subscriptionManager
                     .addSubscription(

--- a/event-stream/common/src/main/java/net/consensys/besu/plugins/stream/core/config/DomainObjectTypeConverter.java
+++ b/event-stream/common/src/main/java/net/consensys/besu/plugins/stream/core/config/DomainObjectTypeConverter.java
@@ -12,36 +12,16 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package net.consensys.besu.plugins.stream.api.config;
+package net.consensys.besu.plugins.stream.core.config;
 
-import net.consensys.besu.plugins.stream.core.config.EventSchemas;
 import net.consensys.besu.plugins.stream.model.DomainObjectType;
-import net.consensys.besu.plugins.types.Address;
 
-import java.io.File;
-import java.util.List;
+import picocli.CommandLine.ITypeConverter;
 
-import org.apache.tuweni.bytes.Bytes32;
+public class DomainObjectTypeConverter implements ITypeConverter<DomainObjectType> {
 
-public interface EventStreamConfiguration {
-
-  String getBrokerUrl();
-
-  String getTopic();
-
-  boolean isEnabled();
-
-  boolean isMetadataDBEnabled();
-
-  List<DomainObjectType> getEnabledTopics();
-
-  List<Address> getLogFilterAddresses();
-
-  List<List<Bytes32>> getLogFilterTopics();
-
-  EventSchemas getEventSchemas();
-
-  File getEventSchemasFile();
-
-  void loadEventSchemas();
+  @Override
+  public DomainObjectType convert(String value) throws Exception {
+    return DomainObjectType.valueOf(value.toUpperCase());
+  }
 }

--- a/event-stream/kafka/src/main/java/net/consensys/besu/plugin/kafka/KafkaPluginConfiguration.java
+++ b/event-stream/kafka/src/main/java/net/consensys/besu/plugin/kafka/KafkaPluginConfiguration.java
@@ -16,8 +16,10 @@ package net.consensys.besu.plugin.kafka;
 
 import net.consensys.besu.plugins.stream.api.config.CommonConfiguration;
 import net.consensys.besu.plugins.stream.core.config.AddressTypeConverter;
+import net.consensys.besu.plugins.stream.core.config.DomainObjectTypeConverter;
 import net.consensys.besu.plugins.stream.core.config.LogFilterTopicsWrapper;
 import net.consensys.besu.plugins.stream.core.config.TopicTypeConverter;
+import net.consensys.besu.plugins.stream.model.DomainObjectType;
 import net.consensys.besu.plugins.types.Address;
 
 import java.io.File;
@@ -125,6 +127,18 @@ public final class KafkaPluginConfiguration extends CommonConfiguration {
   @Override
   public void setMetadataDBEnabled(final boolean metadataDBEnabled) {
     super.setMetadataDBEnabled(metadataDBEnabled);
+  }
+
+  @Option(
+      names = {"--plugin-kafka-enabled-topic", "--plugin-kafka-enabled-topics"},
+      paramLabel = "<topic name>",
+      split = ",",
+      arity = "1..*",
+      description = "Comma separated list of topics to enable",
+      converter = DomainObjectTypeConverter.class)
+  @Override
+  public void setEnabledTopics(final List<DomainObjectType> enabledTopics) {
+    super.setEnabledTopics(enabledTopics);
   }
 
   @Option(names = "--plugin-kafka-log-filter-topics", converter = TopicTypeConverter.class)

--- a/event-stream/kafka/src/test/java/net/consensys/besu/plugin/kafka/KafkaPluginConfigurationTest.java
+++ b/event-stream/kafka/src/test/java/net/consensys/besu/plugin/kafka/KafkaPluginConfigurationTest.java
@@ -16,11 +16,14 @@ package net.consensys.besu.plugin.kafka;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import net.consensys.besu.plugins.stream.model.DomainObjectType;
+
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
 
 public class KafkaPluginConfigurationTest {
 
@@ -45,5 +48,34 @@ public class KafkaPluginConfigurationTest {
     assertThat(configuration.properties().get(KafkaPluginConfiguration.SASL_CONFIG_PROPERTY_KEY))
         .isEqualTo(
             "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"DUMMY_USERNAME\" password=\"DUMMY_PASSWORD\";");
+  }
+
+  @Test
+  public void pluginKafkaEnabledTopicIsParsedCorrectly() {
+    final KafkaPluginConfiguration kafkaPluginConfiguration = new KafkaPluginConfiguration();
+    final CommandLine commandLine = new CommandLine(kafkaPluginConfiguration);
+
+    commandLine.parseArgs("--plugin-kafka-enabled-topic", "BLOCK");
+    assertThat(kafkaPluginConfiguration.getEnabledTopics()).containsExactly(DomainObjectType.BLOCK);
+
+    commandLine.parseArgs("--plugin-kafka-enabled-topic", "block");
+    assertThat(kafkaPluginConfiguration.getEnabledTopics()).containsExactly(DomainObjectType.BLOCK);
+
+    commandLine.parseArgs("--plugin-kafka-enabled-topics", "block,log");
+    assertThat(kafkaPluginConfiguration.getEnabledTopics())
+        .containsExactlyInAnyOrder(DomainObjectType.LOG, DomainObjectType.BLOCK);
+  }
+
+  @Test
+  public void allTopicsShouldBeEnabledByDefault() {
+    final KafkaPluginConfiguration kafkaPluginConfiguration = new KafkaPluginConfiguration();
+    final CommandLine commandLine = new CommandLine(kafkaPluginConfiguration);
+
+    assertThat(kafkaPluginConfiguration.getEnabledTopics())
+        .containsExactly(DomainObjectType.values());
+
+    commandLine.parseArgs();
+    assertThat(kafkaPluginConfiguration.getEnabledTopics())
+        .containsExactly(DomainObjectType.values());
   }
 }


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

## PR Description

As a Besu node admin I would like to be able to disable specific topics in the event stream feature so that topics that I don't need are not published to the broker. For instance, disable the Blocks topic.

add new CLI option : `--plugin-kafka-enabled-topic=LOG,BLOCK`

## Acceptance Criteria

- Be able to disable a specific topic using the usual configuration system
- Default should be the current behaviour with all topics enabled
- Displaying disabled/enabled topics in a log when starting would be a plus

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.