### PR TITLE
Feature/test nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,10 +244,6 @@ workflows:
       - schedule:
           # every hour
           cron: "0 * * * *"
-          filters:
-            branches:
-              only:
-                - feature/test-nightly
     jobs:
       - build
       - integrationTests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,11 @@ workflows:
     triggers:
       - schedule:
           # every hour
-          cron: "0 * * * *"
+          cron: "42 * * * *"
+          filters:
+            branches:
+              only:
+                - /feature.*/
     jobs:
       - build
       - integrationTests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,10 @@ jobs:
       - run:
           name: Integration test - Kafka Plugin
           command : docker-compose -f docker-compose-kafka.yml run integration-tests
-      - notify
+      - run:
+          name: "Failure: output container logs to console"
+          command: |
+            docker-compose -f cdocker-compose-kafka.yml logs integration-tests
 
 
   build:
@@ -257,20 +260,6 @@ workflows:
   pipeline:
     jobs:
       - build
-      - test:
+      - integrationTests:
           requires:
             - build
-      - javaDoc
-      - acceptanceTests:
-          requires:
-            - build
-      - upload-distribution:
-          requires:
-            - build
-            - test
-            - acceptanceTests
-          filters:
-            branches:
-              only:
-                - master
-                - /release-.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,15 +239,15 @@ jobs:
 
 workflows:
   version: 2
-  nightly:
+  nightlyTest:
     triggers:
       - schedule:
-          # every day at 12am UTC
-          cron: "0 0 * * *"
+          # every hour
+          cron: "0 * * * *"
           filters:
             branches:
               only:
-                - master
+                - feature/test-nightly
     jobs:
       - build
       - integrationTests:
@@ -256,6 +256,3 @@ workflows:
   pipeline:
     jobs:
       - build
-      - integrationTests:
-          requires:
-            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,8 @@ jobs:
       - prepare
       - run:
           name: Integration test - Kafka Plugin
-          command: docker-compose -f docker-compose-kafka.yml run integration-tests
+          command : docker-compose -f docker-compose-kafka.yml run integration-tests
+      - notify
 
 
   build:
@@ -239,15 +240,15 @@ jobs:
 
 workflows:
   version: 2
-  nightlyTest:
+  nightly:
     triggers:
       - schedule:
-          # every hour
-          cron: "42 * * * *"
+          # every day at 12am UTC
+          cron: "0 0 * * *"
           filters:
             branches:
               only:
-                - /feature.*/
+                - master
     jobs:
       - build
       - integrationTests:
@@ -256,3 +257,20 @@ workflows:
   pipeline:
     jobs:
       - build
+      - test:
+          requires:
+            - build
+      - javaDoc
+      - acceptanceTests:
+          requires:
+            - build
+      - upload-distribution:
+          requires:
+            - build
+            - test
+            - acceptanceTests
+          filters:
+            branches:
+              only:
+                - master
+                - /release-.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run:
           name: "Failure: output container logs to console"
           command: |
-            docker-compose -f docker-compose-kafka.yml logs integration-tests
+            journalctl -u docker CONTAINER_TAG=log-kafka
 
 
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run:
           name: "Failure: output container logs to console"
           command: |
-            docker-compose -f cdocker-compose-kafka.yml logs integration-tests
+            docker-compose -f docker-compose-kafka.yml logs integration-tests
 
 
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,7 @@ jobs:
       - prepare
       - run:
           name: Integration test - Kafka Plugin
-          command : docker-compose -f docker-compose-kafka.yml run integration-tests
-      - run:
-          name: "Failure: output container logs to console"
-          command: |
-            journalctl -u docker CONTAINER_TAG=log-kafka
+          command: docker-compose -f docker-compose-kafka.yml run integration-tests
 
 
   build:
@@ -134,16 +130,16 @@ jobs:
       - run:
           name: Collecting reports
           command: |
-              find . -type d -regex ".*/build/reports/tests/integrationTest" | while read dir; do
-                  module=`echo $dir | sed -e 's/build\/reports\/tests\/integrationTest//'`
-                  mkdir -p ~/reports/integrationTest/"$module"
-                  (cd "$dir" && tar c .) | (cd ~/reports/integrationTest/"$module" && tar x)
-              done
-              find . -type d -regex ".*/build/reports/jacoco/test/html" | while read dir; do
-                  module=`echo $dir | sed -e 's/build\/reports\/jacoco\/test\/html//'`
-                  mkdir -p ~/reports/jacoco/"$module"
-                  (cd "$dir" && tar c .) | (cd ~/reports/jacoco/"$module" && tar x)
-              done
+            find . -type d -regex ".*/build/reports/tests/integrationTest" | while read dir; do
+                module=`echo $dir | sed -e 's/build\/reports\/tests\/integrationTest//'`
+                mkdir -p ~/reports/integrationTest/"$module"
+                (cd "$dir" && tar c .) | (cd ~/reports/integrationTest/"$module" && tar x)
+            done
+            find . -type d -regex ".*/build/reports/jacoco/test/html" | while read dir; do
+                module=`echo $dir | sed -e 's/build\/reports\/jacoco\/test\/html//'`
+                mkdir -p ~/reports/jacoco/"$module"
+                (cd "$dir" && tar c .) | (cd ~/reports/jacoco/"$module" && tar x)
+            done
           when: always
 
       - store_test_results:
@@ -207,11 +203,11 @@ jobs:
       - run:
           name: Collecting reports
           command: |
-              find . -type d -regex ".*/build/reports/tests/acceptanceTest" | while read dir; do
-                  module=`echo $dir | sed -e 's/build\/reports\/tests\/acceptanceTest//'`
-                  mkdir -p ~/reports/acceptanceTest/"$module"
-                  (cd "$dir" && tar c .) | (cd ~/reports/acceptanceTest/"$module" && tar x)
-              done
+            find . -type d -regex ".*/build/reports/tests/acceptanceTest" | while read dir; do
+                module=`echo $dir | sed -e 's/build\/reports\/tests\/acceptanceTest//'`
+                mkdir -p ~/reports/acceptanceTest/"$module"
+                (cd "$dir" && tar c .) | (cd ~/reports/acceptanceTest/"$module" && tar x)
+            done
           when: always
 
       - run:

--- a/docker-compose-kafka.yml
+++ b/docker-compose-kafka.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 
 services:
 

--- a/docker-compose-kafka.yml
+++ b/docker-compose-kafka.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 
 services:
 

--- a/docker-compose-kafka.yml
+++ b/docker-compose-kafka.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '3.0'
 
 services:
 

--- a/docker-compose-kafka.yml
+++ b/docker-compose-kafka.yml
@@ -3,16 +3,11 @@ version: '2'
 services:
 
     kafka:
-        image: openzipkin/zipkin-kafka
+        image: spotify/kafka
         container_name: kafka
         ports:
             - 2181:2181
             - 9092:9092
-            - 19092:19092
-        logging:
-            driver: journald
-            options:
-                tag: log-kafka
     besu:
         build:
             context: .

--- a/docker-compose-kafka.yml
+++ b/docker-compose-kafka.yml
@@ -8,6 +8,12 @@ services:
         ports:
             - 2181:2181
             - 9092:9092
+        healthcheck:
+            test: nc -z localhost 9092 || exit -1
+            interval: 10s
+            timeout: 5s
+            retries: 3
+            start_period: 10s
     besu:
         build:
             context: .

--- a/docker-compose-kafka.yml
+++ b/docker-compose-kafka.yml
@@ -12,8 +12,7 @@ services:
             test: nc -z localhost 9092 || exit -1
             interval: 10s
             timeout: 5s
-            retries: 3
-            start_period: 10s
+            retries: 10
     besu:
         build:
             context: .

--- a/docker-compose-kafka.yml
+++ b/docker-compose-kafka.yml
@@ -9,7 +9,10 @@ services:
             - 2181:2181
             - 9092:9092
             - 19092:19092
-
+        logging:
+            driver: journald
+            options:
+                tag: log-kafka
     besu:
         build:
             context: .

--- a/integration-tests/src/test/java/net/consensys/besu/plugins/integration/tests/kafka/KafkaEventTest.java
+++ b/integration-tests/src/test/java/net/consensys/besu/plugins/integration/tests/kafka/KafkaEventTest.java
@@ -59,7 +59,7 @@ public class KafkaEventTest {
 
     // polling
     final ArrayList<String> eventsToCheck = new ArrayList<>();
-    eventsToCheck.add(Event.Type.BLOCK_ADDED);
+    eventsToCheck.add(Event.Type.LOG_EMITTED);
     eventsToCheck.add(Event.Type.BLOCK_PROPAGATED);
 
     while (!eventsToCheck.isEmpty()) {

--- a/integration-tests/src/test/java/net/consensys/besu/plugins/integration/tests/kafka/KafkaEventTest.java
+++ b/integration-tests/src/test/java/net/consensys/besu/plugins/integration/tests/kafka/KafkaEventTest.java
@@ -59,7 +59,7 @@ public class KafkaEventTest {
 
     // polling
     final ArrayList<String> eventsToCheck = new ArrayList<>();
-    eventsToCheck.add(Event.Type.LOG_EMITTED);
+    eventsToCheck.add(Event.Type.BLOCK_ADDED);
     eventsToCheck.add(Event.Type.BLOCK_PROPAGATED);
 
     while (!eventsToCheck.isEmpty()) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/besu-plugins/blob/master/CONTRIBUTING.md -->

Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

## PR Description

Try to fix the flaky test of Besu nightly plugins. The Kafka does not always start and the test fails when trying to retrieve events from the Kafka.
To correct this:
- We are changing the Kafka image
- We add a healthcheck to wait for the Kafka to start before running Besu and the test

### Test performed

Run the build for a week (once per hour)

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.