### PR TITLE
Fix Invalid value for option plugin-kafka-log-filter-addresses

### DIFF
--- a/event-stream/kafka/src/main/java/net/consensys/besu/plugin/kafka/KafkaPluginConfiguration.java
+++ b/event-stream/kafka/src/main/java/net/consensys/besu/plugin/kafka/KafkaPluginConfiguration.java
@@ -147,7 +147,13 @@ public final class KafkaPluginConfiguration extends CommonConfiguration {
     super.setLogFilterTopicsWrapper(logFilterTopicsWrapper);
   }
 
-  @Option(names = "--plugin-kafka-log-filter-addresses", converter = AddressTypeConverter.class)
+  @Option(
+      names = "--plugin-kafka-log-filter-addresses",
+      paramLabel = "<address>",
+      split = ",",
+      arity = "1..*",
+      description = "Comma separated list of addresses",
+      converter = AddressTypeConverter.class)
   @Override
   public void setLogFilterAddresses(final List<Address> logFilterAddresses) {
     super.setLogFilterAddresses(logFilterAddresses);

--- a/event-stream/kafka/src/test/java/net/consensys/besu/plugin/kafka/KafkaPluginConfigurationTest.java
+++ b/event-stream/kafka/src/test/java/net/consensys/besu/plugin/kafka/KafkaPluginConfigurationTest.java
@@ -17,9 +17,12 @@ package net.consensys.besu.plugin.kafka;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import net.consensys.besu.plugins.stream.model.DomainObjectType;
+import net.consensys.besu.plugins.types.Address;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -64,6 +67,27 @@ public class KafkaPluginConfigurationTest {
     commandLine.parseArgs("--plugin-kafka-enabled-topics", "block,log");
     assertThat(kafkaPluginConfiguration.getEnabledTopics())
         .containsExactlyInAnyOrder(DomainObjectType.LOG, DomainObjectType.BLOCK);
+  }
+
+  @Test
+  public void pluginKafkaLogFilterAddressesIsParsedCorrectly() {
+    final KafkaPluginConfiguration kafkaPluginConfiguration = new KafkaPluginConfiguration();
+    final CommandLine commandLine = new CommandLine(kafkaPluginConfiguration);
+
+    List<Address> addresses =
+        Arrays.asList(
+            Address.fromHexString("0xF216B6b2D9E76F94f97bE597e2Cec81730520585"),
+            Address.fromHexString("0xDDDDB6b2D9E76F94f97bE597e2Cec81730520572"));
+
+    commandLine.parseArgs("--plugin-kafka-log-filter-addresses", addresses.get(0).toHexString());
+    assertThat(kafkaPluginConfiguration.getLogFilterAddresses()).containsExactly(addresses.get(0));
+
+    commandLine.parseArgs(
+        "--plugin-kafka-log-filter-addresses",
+        addresses.get(0).toHexString(),
+        addresses.get(1).toHexString());
+    assertThat(kafkaPluginConfiguration.getLogFilterAddresses())
+        .containsExactlyInAnyOrderElementsOf(addresses);
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/besu-plugins/blob/master/CONTRIBUTING.md -->

## PR Description

Fix Invalid value for option '--plugin-kafka-log-filter-addresses' if we try to put several contract addresses

- Command Line
`--plugin-kafka-log-filter-topics=["0xd3610b1c54575b7f4f0dc03d210b8ac55624ae007679b7a928a4f25a709331a8","0xd3610b1c54575b7f4f0dc03d210b8ac55624ae007679b7a928a4f25a709331a7"]` 

- Config file
`plugin-kafka-log-filter-addresses=["0xF216B6b2D9E76F94f97bE597e2Cec81730520587","0xF216B6b2D9E76F94f97bE597e2Cec81730520586"]`

https://docs.plus.pegasys.tech/en/stable/Reference/CLI-Syntax/#plugin-kafka-log-filter-addresses

### Test performed

Send event on a local click network and connected to a Kafka (with invalid filters, no filters, multiple filters)

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.