### PR TITLE
use configurations.runtimeClasspath.collect to create the fat jar

### DIFF
--- a/event-stream/kafka/build.gradle
+++ b/event-stream/kafka/build.gradle
@@ -64,6 +64,6 @@ jar {
       'Implementation-Version': calculateVersion()
       )
   }
-  from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+  from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
   exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'
 }


### PR DESCRIPTION
This won't work with gradle 7

## Documentation

- [x] I thought about documentation and added the `documentation` label to this PR if updates are required.